### PR TITLE
Restore branded README header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,16 @@
+<p align="center">
+  <img src="docs/snitch_logo.png" alt="Snitch logo" width="320">
+</p>
 
+<p align="center"><strong>Snitch watches your AI agent so you don't have to.</strong></p>
 
-**Snitch watches your AI agent so you don't have to.**
+<p align="center"><a href="https://snitchworks.com">snitchworks.com</a> · <a href="#install">Install</a> · <a href="#help-train-snitch-coming-soon">Help train Snitch</a> · <a href="#roadmap">Roadmap</a></p>
 
-[snitchworks.com](https://snitchworks.com) · [Install](#install) · [Roadmap](#roadmap)
-
-Snitch is a deterministic prose lie detector for AI coding agents. It watches transcripts from [Cursor](https://cursor.com), [Claude Code](https://claude.com/claude-code), [Codex](https://github.com/openai/codex), [Pi](https://pi.dev), and [OpenCode](https://opencode.ai), extracts high-confidence claims from assistant text ("all tests pass", "I committed this"), and flags claims contradicted by evidence: tool calls (including subagent merges), tool output, filesystem, git, session lookback (3 prior turns), and same-turn consistency.
+<p align="center">
+  <span style="display: inline-block; max-width: 720px; text-align: justify;">
+    Snitch is a deterministic prose lie detector for AI coding agents. It watches transcripts from <a href="https://cursor.com">Cursor</a>, <a href="https://claude.com/claude-code">Claude Code</a>, <a href="https://github.com/openai/codex">Codex</a>, <a href="https://pi.dev">Pi</a>, and <a href="https://opencode.ai">OpenCode</a>, extracts high-confidence claims from assistant text ("all tests pass", "I committed this"), and flags claims contradicted by evidence: tool calls (including subagent merges), tool output, filesystem, git, session lookback (3 prior turns), and same-turn consistency.
+  </span>
+</p>
 
 ## Install
 
@@ -53,8 +59,6 @@ snitch start
 
 ## Quick start
 
-
-
 ### Menu bar (everyday use)
 
 Open Snitch Bar once — it lives in the menu bar with no Dock icon:
@@ -64,7 +68,6 @@ snitch start
 ```
 
 From the Snitch menu:
-
 
 | Action | What it does |
 | ------ | ------------ |
@@ -93,12 +96,10 @@ snitch doctor             # install checklist
 
 Snitch stores every agent **turn** as a **run** (with a verdict and claims). A **lie** is a high-confidence prose claim inside a run that evidence contradicts.
 
-
-| View                    | Best for         | What you see                                                                |
-| ----------------------- | ---------------- | --------------------------------------------------------------------------- |
-| `snitch log --run <id>` | One agent turn   | Full breakdown — verdict, prompt, tool calls, every claim with evidence.    |
-| `snitch dashboard`      | Browsing history | Interactive TUI — flip between runs and lies, filter, search, live refresh. |
-
+| View | Best for | What you see |
+| ---- | -------- | ------------ |
+| **`snitch log --run <id>`** | One agent turn | Full breakdown — verdict, prompt, tool calls, every claim with evidence. |
+| **`snitch dashboard`** | Browsing history | Interactive TUI — flip between runs and lies, filter, search, live refresh. |
 
 **Menu bar shortcuts:** **View Details…** runs `snitch log --run <id>` for the latest lie. **History ▸ Open Dashboard…** runs `snitch dashboard`.
 
@@ -111,10 +112,7 @@ snitch dashboard
 
 ## Commands
 
-
-
 ### Menu bar (Snitch Bar)
-
 
 | Item | Description |
 | ---- | ----------- |
@@ -126,11 +124,7 @@ snitch dashboard
 | **Preferences…** | Edit `~/.snitch/config.yaml` |
 | **Quit Snitch Bar** | Stop `snitchd` and exit |
 
-
-
-
 ### Terminal (CLI)
-
 
 | Command | Description |
 | ------- | ----------- |
@@ -163,22 +157,21 @@ The first notification triggers the macOS permission prompt for Snitch Bar.
 ## Lie types
 
 
-| Type                 | Example prose              | Contradiction                                          |
-| -------------------- | -------------------------- | ------------------------------------------------------ |
-| `test_pass`          | "all tests pass"           | No test run, or test output shows failure              |
-| `command_ran`        | "I ran the command"        | No shell tool call in the turn                         |
-| `command_succeeded`  | "command ran successfully" | Shell exited with error                                |
-| `committed`          | "I committed"              | No new commit since turn start                         |
-| `pushed`             | "I pushed"                 | No `git push` shell call                               |
-| `file_created`       | "created foo.go"           | No matching `Write` + file missing                     |
-| `file_modified`      | "updated foo.go"           | No matching `Write`/`StrReplace` + file missing        |
+| Type                 | Example prose              | Contradiction                                      |
+| -------------------- | -------------------------- | -------------------------------------------------- |
+| `test_pass`          | "all tests pass"           | No test run, or test output shows failure          |
+| `command_ran`        | "I ran the command"        | No shell tool call in the turn                     |
+| `command_succeeded`  | "command ran successfully" | Shell exited with error                            |
+| `committed`          | "I committed"              | No new commit since turn start                     |
+| `pushed`             | "I pushed"                 | No `git push` shell call                           |
+| `file_created`       | "created foo.go"           | No matching `Write` + file missing                 |
+| `file_modified`      | "updated foo.go"           | No matching `Write`/`StrReplace` + file missing    |
 | `file_deleted`       | "deleted foo.go"           | No matching `Delete`/`StrReplace` + file still present |
-| `stub`               | "fully implemented"        | Written file is a placeholder (`panic("TODO")`, …)     |
-| `no_action`          | action claims              | Zero tool calls in the turn                            |
-| `self_contradiction` | "won't modify X"           | Tool call edits X in the same turn                     |
-| `count_mismatch`     | "updated all 5 files"      | File tool-call count ≠ 5                               |
-| `negation_violation` | "did not touch tests"      | `*_test.*` file edited in the turn                     |
-
+| `stub`               | "fully implemented"        | Written file is a placeholder (`panic("TODO")`, …) |
+| `no_action`          | action claims              | Zero tool calls in the turn                        |
+| `self_contradiction` | "won't modify X"           | Tool call edits X in the same turn                 |
+| `count_mismatch`     | "updated all 5 files"      | File tool-call count ≠ 5                           |
+| `negation_violation` | "did not touch tests"      | `*_test.*` file edited in the turn                 |
 
 
 
@@ -199,15 +192,13 @@ Recap segments (`### Summary`, `## Summary`, horizontal rules) are tagged separa
 
 Snitch watches transcripts from five AI coding agents. Cursor is enabled by default; the others are opt-in.
 
-
-| Agent           | Format | Location                              | Enable                                              |
-| --------------- | ------ | ------------------------------------- | --------------------------------------------------- |
-| **Cursor**      | JSONL  | `~/.cursor/projects`                  | on by default                                       |
-| **Claude Code** | JSONL  | `~/.claude/projects`                  | `snitch config set platforms.claude.enabled true`   |
-| **Codex**       | JSONL  | `~/.codex/sessions`                   | `snitch config set platforms.codex.enabled true`    |
-| **Pi**          | JSONL  | `~/.pi/agent/sessions`                | `snitch config set platforms.pi.enabled true`       |
-| **OpenCode**    | SQLite | `~/.local/share/opencode/opencode.db` | `snitch config set platforms.opencode.enabled true` |
-
+| Agent | Format | Location | Enable |
+| ----- | ------ | -------- | ------ |
+| **Cursor** | JSONL | `~/.cursor/projects` | on by default |
+| **Claude Code** | JSONL | `~/.claude/projects` | `snitch config set platforms.claude.enabled true` |
+| **Codex** | JSONL | `~/.codex/sessions` | `snitch config set platforms.codex.enabled true` |
+| **Pi** | JSONL | `~/.pi/agent/sessions` | `snitch config set platforms.pi.enabled true` |
+| **OpenCode** | SQLite | `~/.local/share/opencode/opencode.db` | `snitch config set platforms.opencode.enabled true` |
 
 After enabling a platform, restart Snitch (`snitch start`). Each platform's claims, tool calls, and shell output are normalized to a common internal vocabulary, so the verification pipeline works identically across all five.
 
@@ -230,10 +221,8 @@ When sharing is enabled (dual opt-in: `telemetry.enabled` + share flag), a share
 
 - **0.3.x (this release):** Multi-harness ingestion (Cursor + Claude Code + Codex + Pi + OpenCode), session lookback, Snitch Bar notifications with app icon.
 - **Coming soon:** Community labeling and opt-in sync of claim sentences + short context to train a false-positive filter.
-- **Later:** A locally-run false-positive classifier trained on community labels.
-- **Snitchworks:** A paid team layer — centralized dashboard, policy engine, semantic claim extraction.
-
-
+- **Later:** A locally-run false-positive classifier trained on community labels — reduces alert noise by filtering regex hits that aren't genuine claims.
+- **Snitchworks:** A paid team layer — centralized dashboard, policy engine, premium semantic claim extraction.
 
 ## Limitations
 


### PR DESCRIPTION
## Summary
- Restore the centered logo / tagline / nav HTML accidentally stripped in the 0.3.2 docs sweep
- Keep the intentional “Help train Snitch (coming soon)” disclosure and gated-off labeling menu/CLI rows

## Test plan
- [ ] Confirm GitHub README renders logo + centered header
- [ ] Confirm Help train Snitch section still says coming soon with payload disclosure


Made with [Cursor](https://cursor.com)