### PR TITLE
Fix Snitch Bar notification auth after Homebrew upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,8 @@
-<p align="center">
-  <img src="docs/snitch_logo.png" alt="Snitch logo" width="320">
-</p>
+**Snitch watches your AI agent so you don't have to.**
 
-<p align="center"><strong>Snitch watches your AI agent so you don't have to.</strong></p>
+[Install](#install) · [Help train Snitch](#help-train-snitch-coming-soon) · [Roadmap](#roadmap)
 
-<p align="center"><a href="https://snitchworks.com">snitchworks.com</a> · <a href="#install">Install</a> · <a href="#help-train-snitch-coming-soon">Help train Snitch</a> · <a href="#roadmap">Roadmap</a></p>
-
-<p align="center">
-  <span style="display: inline-block; max-width: 720px; text-align: justify;">
-    Snitch is a deterministic prose claim verifier for AI coding agents. It watches transcripts from <a href="https://cursor.com">Cursor</a>, <a href="https://claude.com/claude-code">Claude Code</a>, <a href="https://github.com/openai/codex">Codex</a>, <a href="https://pi.dev">Pi</a>, and <a href="https://opencode.ai">OpenCode</a>, extracts high-confidence claims from assistant text ("all tests pass", "I committed this"), and flags claims contradicted by evidence: tool calls (including subagent merges), tool output, filesystem, git, session lookback (3 prior turns), and same-turn consistency.
-  </span>
-</p>
+Snitch is a deterministic prose claim verifier for AI coding agents. It watches transcripts from [Cursor](https://cursor.com), [Claude Code](https://claude.com/claude-code), [Codex](https://github.com/openai/codex), [Pi](https://pi.dev), and [OpenCode](https://opencode.ai), extracts high-confidence claims from assistant text ("all tests pass", "I committed this"), and flags claims contradicted by evidence: tool calls (including subagent merges), tool output, filesystem, git, session lookback (3 prior turns), and same-turn consistency.
 
 ## Install
 
@@ -59,6 +51,8 @@ snitch start
 
 ## Quick start
 
+
+
 ### Menu bar (everyday use)
 
 Open Snitch Bar once — it lives in the menu bar with no Dock icon:
@@ -69,15 +63,17 @@ snitch start
 
 From the Snitch menu:
 
-| Action | What it does |
-| ------ | ------------ |
-| **Snitching…** / **Paused** / **Offline** | Current detection status |
-| **Start Snitching** / **Stop Snitching** | Turn claim verification on or off |
-| **Latest: …** | Preview of the most recent flagged claim (type + short quote) |
-| **View Details…** | Open Terminal with full details (`snitch log --run <id>`) |
-| **History ▸ Open Dashboard…** | Open the interactive TUI (`snitch dashboard`) |
-| **Preferences…** | Open `~/.snitch/config.yaml` |
-| **Quit Snitch Bar** | Stop the daemon and exit |
+
+| Action                                    | What it does                                                  |
+| ----------------------------------------- | ------------------------------------------------------------- |
+| **Snitching…** / **Paused** / **Offline** | Current detection status                                      |
+| **Start Snitching** / **Stop Snitching**  | Turn claim verification on or off                             |
+| **Latest: …**                             | Preview of the most recent flagged claim (type + short quote) |
+| **View Details…**                         | Open Terminal with full details (`snitch log --run <id>`)     |
+| **History ▸ Open Dashboard…**             | Open the interactive TUI (`snitch dashboard`)                 |
+| **Preferences…**                          | Open `~/.snitch/config.yaml`                                  |
+| **Quit Snitch Bar**                       | Stop the daemon and exit                                      |
+
 
 When a false claim is caught, the menu bar icon alerts and Snitch Bar may show a Notification Center alert (Snitch app icon). Click **View Details…** for the full verification breakdown, or **History ▸ Open Dashboard…** to browse history.
 
@@ -96,10 +92,12 @@ snitch doctor             # install checklist
 
 Snitch stores every agent **turn** as a **run** (with a verdict and claims). A **false claim** is a high-confidence prose claim inside a run that evidence contradicts.
 
-| View | Best for | What you see |
-| ---- | -------- | ------------ |
-| **`snitch log --run <id>`** | One agent turn | Full breakdown — verdict, prompt, tool calls, every claim with evidence. |
-| **`snitch dashboard`** | Browsing history | Interactive TUI — flip between runs and flagged claims, filter, search, live refresh. |
+
+| View                    | Best for         | What you see                                                                          |
+| ----------------------- | ---------------- | ------------------------------------------------------------------------------------- |
+| `snitch log --run <id>` | One agent turn   | Full breakdown — verdict, prompt, tool calls, every claim with evidence.              |
+| `snitch dashboard`      | Browsing history | Interactive TUI — flip between runs and flagged claims, filter, search, live refresh. |
+
 
 **Menu bar shortcuts:** **View Details…** runs `snitch log --run <id>` for the latest flagged claim. **History ▸ Open Dashboard…** runs `snitch dashboard`.
 
@@ -112,31 +110,38 @@ snitch dashboard
 
 ## Commands
 
+
+
 ### Menu bar (Snitch Bar)
 
-| Item | Description |
-| ---- | ----------- |
-| **Start / Stop Snitching** | Pause or resume claim verification |
-| Alert icon | Flashes when a new false claim is caught |
-| **Latest: …** | Disabled preview of the most recent flagged claim |
-| **View Details…** | Open `snitch log --run <id>` for the latest flagged claim |
-| **History ▸ Open Dashboard…** | Open `snitch dashboard` in Terminal |
-| **Preferences…** | Edit `~/.snitch/config.yaml` |
-| **Quit Snitch Bar** | Stop `snitchd` and exit |
+
+| Item                          | Description                                               |
+| ----------------------------- | --------------------------------------------------------- |
+| **Start / Stop Snitching**    | Pause or resume claim verification                        |
+| Alert icon                    | Flashes when a new false claim is caught                  |
+| **Latest: …**                 | Disabled preview of the most recent flagged claim         |
+| **View Details…**             | Open `snitch log --run <id>` for the latest flagged claim |
+| **History ▸ Open Dashboard…** | Open `snitch dashboard` in Terminal                       |
+| **Preferences…**              | Edit `~/.snitch/config.yaml`                              |
+| **Quit Snitch Bar**           | Stop `snitchd` and exit                                   |
+
+
+
 
 ### Terminal (CLI)
 
-| Command | Description |
-| ------- | ----------- |
-| `snitch start` | Open Snitch Bar |
-| `snitch status` | Detection status (`--detailed` for per-harness stats) |
-| `snitch log --run <id>` | Full verification detail for one run (`--trace`, `--json`) |
-| `snitch log --harness <name>` | List recent runs for one agent platform |
-| `snitch dashboard` | Interactive TUI for runs and flagged claims (`--harness` filter) |
-| `snitch replay <path>` | Run any transcript through the pipeline offline — measure accuracy on your own sessions |
-| `snitch doctor` | Debug install checklist (per-harness) |
-| `snitch uninstall` | Remove daemon and binaries (`--purge` for data) |
-| `snitch config` | View/set configuration |
+
+| Command                       | Description                                                                             |
+| ----------------------------- | --------------------------------------------------------------------------------------- |
+| `snitch start`                | Open Snitch Bar                                                                         |
+| `snitch status`               | Detection status (`--detailed` for per-harness stats)                                   |
+| `snitch log --run <id>`       | Full verification detail for one run (`--trace`, `--json`)                              |
+| `snitch log --harness <name>` | List recent runs for one agent platform                                                 |
+| `snitch dashboard`            | Interactive TUI for runs and flagged claims (`--harness` filter)                        |
+| `snitch replay <path>`        | Run any transcript through the pipeline offline — measure accuracy on your own sessions |
+| `snitch doctor`               | Debug install checklist (per-harness)                                                   |
+| `snitch uninstall`            | Remove daemon and binaries (`--purge` for data)                                         |
+| `snitch config`               | View/set configuration                                                                  |
 
 
 Snitch runs passively after install — it reads each enabled agent's local transcripts (see [Supported agents](#supported-agents)); Cursor's `~/.cursor/projects` is watched by default.
@@ -157,26 +162,27 @@ The first notification triggers the macOS permission prompt for Snitch Bar.
 ## Claim types
 
 
-| Type                 | Example prose              | Contradiction                                      |
-| -------------------- | -------------------------- | -------------------------------------------------- |
-| `test_pass`          | "all tests pass"           | No test run, or test output shows failure          |
-| `command_ran`        | "I ran the command"        | No shell tool call in the turn                     |
-| `command_succeeded`  | "command ran successfully" | Shell exited with error                            |
-| `committed`          | "I committed"              | No new commit since turn start                     |
-| `pushed`             | "I pushed"                 | No `git push` shell call                           |
-| `file_created`       | "created foo.go"           | No matching `Write` + file missing                 |
-| `file_modified`      | "updated foo.go"           | No matching `Write`/`StrReplace` + file missing    |
-| `file_deleted`       | "deleted foo.go"           | No matching `Delete`/`StrReplace` + file still present |
-| `stub`               | "fully implemented"        | Written file is a placeholder (`panic("TODO")`, …) |
-| `no_action`          | action claims              | Zero mutating tool calls in the turn               |
-| `self_contradiction` | "won't modify X"           | Tool call edits X in the same turn                 |
-| `count_mismatch`     | "updated all 5 files"      | File tool-call count ≠ 5                           |
-| `negation_violation` | "did not touch tests"      | `*_test.*` file edited in the turn                 |
-| `tool_write`         | Write tool call            | File missing / empty after write                   |
-| `tool_str_replace`   | StrReplace tool call       | Edit not reflected on disk                         |
-| `tool_delete`        | Delete tool call           | File still exists                                  |
-| `tool_shell`         | Shell tool call            | Command evidence mismatch                          |
-| `tool_read` / `tool_glob` / `tool_task` | Read / Glob / Task | Tool effect vs disk / subagent evidence |
+| Type                                    | Example prose              | Contradiction                                          |
+| --------------------------------------- | -------------------------- | ------------------------------------------------------ |
+| `test_pass`                             | "all tests pass"           | No test run, or test output shows failure              |
+| `command_ran`                           | "I ran the command"        | No shell tool call in the turn                         |
+| `command_succeeded`                     | "command ran successfully" | Shell exited with error                                |
+| `committed`                             | "I committed"              | No new commit since turn start                         |
+| `pushed`                                | "I pushed"                 | No `git push` shell call                               |
+| `file_created`                          | "created foo.go"           | No matching `Write` + file missing                     |
+| `file_modified`                         | "updated foo.go"           | No matching `Write`/`StrReplace` + file missing        |
+| `file_deleted`                          | "deleted foo.go"           | No matching `Delete`/`StrReplace` + file still present |
+| `stub`                                  | "fully implemented"        | Written file is a placeholder (`panic("TODO")`, …)     |
+| `no_action`                             | action claims              | Zero mutating tool calls in the turn                   |
+| `self_contradiction`                    | "won't modify X"           | Tool call edits X in the same turn                     |
+| `count_mismatch`                        | "updated all 5 files"      | File tool-call count ≠ 5                               |
+| `negation_violation`                    | "did not touch tests"      | `*_test.*` file edited in the turn                     |
+| `tool_write`                            | Write tool call            | File missing / empty after write                       |
+| `tool_str_replace`                      | StrReplace tool call       | Edit not reflected on disk                             |
+| `tool_delete`                           | Delete tool call           | File still exists                                      |
+| `tool_shell`                            | Shell tool call            | Command evidence mismatch                              |
+| `tool_read` / `tool_glob` / `tool_task` | Read / Glob / Task         | Tool effect vs disk / subagent evidence                |
+
 
 
 
@@ -197,13 +203,15 @@ Recap segments (`### Summary`, `## Summary`, horizontal rules) are tagged separa
 
 Snitch watches transcripts from five AI coding agents. Cursor is enabled by default; the others are opt-in.
 
-| Agent | Format | Location | Enable |
-| ----- | ------ | -------- | ------ |
-| **Cursor** | JSONL | `~/.cursor/projects` | on by default |
-| **Claude Code** | JSONL | `~/.claude/projects` | `snitch config set platforms.claude.enabled true` |
-| **Codex** | JSONL | `~/.codex/sessions` | `snitch config set platforms.codex.enabled true` |
-| **Pi** | JSONL | `~/.pi/agent/sessions` | `snitch config set platforms.pi.enabled true` |
-| **OpenCode** | SQLite | `~/.local/share/opencode/opencode.db` | `snitch config set platforms.opencode.enabled true` |
+
+| Agent           | Format | Location                              | Enable                                              |
+| --------------- | ------ | ------------------------------------- | --------------------------------------------------- |
+| **Cursor**      | JSONL  | `~/.cursor/projects`                  | on by default                                       |
+| **Claude Code** | JSONL  | `~/.claude/projects`                  | `snitch config set platforms.claude.enabled true`   |
+| **Codex**       | JSONL  | `~/.codex/sessions`                   | `snitch config set platforms.codex.enabled true`    |
+| **Pi**          | JSONL  | `~/.pi/agent/sessions`                | `snitch config set platforms.pi.enabled true`       |
+| **OpenCode**    | SQLite | `~/.local/share/opencode/opencode.db` | `snitch config set platforms.opencode.enabled true` |
+
 
 After enabling a platform, restart Snitch (`snitch start`). Each platform's claims, tool calls, and shell output are normalized to a common internal vocabulary, so the verification pipeline works identically across all five.
 
@@ -224,11 +232,13 @@ When sharing is enabled (dual opt-in: `telemetry.enabled` + share flag), a share
 
 ## Roadmap
 
-- **0.4.x (this release):** Claim-first UX (flagged sentence → checked), `tool_*` types, `UNUserNotificationCenter` alerts.
+- **0.4.x (this release):** Claim-first UX (flagged sentence → checked), `tool_`* types, `UNUserNotificationCenter` alerts.
 - **0.3.x:** Multi-harness ingestion (Cursor + Claude Code + Codex + Pi + OpenCode), session lookback, Snitch Bar notifications with app icon.
 - **Coming soon:** Community labeling and opt-in sync of claim sentences + short context to train a false-positive filter.
 - **Later:** A locally-run false-positive classifier trained on community labels — reduces alert noise by filtering regex hits that aren't genuine claims.
 - **Snitchworks:** A paid team layer — centralized dashboard, policy engine, premium semantic claim extraction.
+
+
 
 ## Limitations
 

--- a/scripts/bundle-snitchbar.sh
+++ b/scripts/bundle-snitchbar.sh
@@ -64,4 +64,13 @@ if [[ -f "$HEAD_PNG" ]]; then
   rm -rf "$(dirname "$ICONSET")"
 fi
 
+# Bind Info.plist + bundle id so UNUserNotificationCenter can authorize.
+# Linker-only adhoc signatures leave Identifier=a.out and break alerts after
+# Homebrew upgrades (UNErrorDomain Code=1 / NotificationsNotAllowed).
+if command -v codesign >/dev/null; then
+  codesign --force --deep --sign - \
+    --identifier "dev.snitch.menubar" \
+    "${APP_DIR}" >/dev/null
+fi
+
 echo "bundled ${APP_DIR}"


### PR DESCRIPTION
## Summary
- Bundle script now adhoc-codesigns `Snitch Bar.app` as `dev.snitch.menubar` with Info.plist bound
- Fixes `UNErrorDomain Code=1` (NotificationsNotAllowed) after Cellar upgrades that left `Identifier=a.out`

## Test plan
- [x] Hot-swap signed app locally → auth `didGrant: 1`, notification `hasError: 0`
- [x] Injected `all tests pass` lie → fail run + notify add succeeded
- [x] Confirm banner / Notification Center entry visible on a fresh brew install after this lands


Made with [Cursor](https://cursor.com)